### PR TITLE
Specify installed version of PyYAML

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,12 @@ ENV TERRAFORM_VERSION=0.11.10
 RUN apk add --no-cache nodejs nodejs-npm python python-dev py-pip build-base bash
 
 RUN npm i serverless -g \
- && pip install stacker stacker_blueprints runway --user \
- && cd /tmp \
- && wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
- && unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
- && mv terraform /usr/local/bin \
- && rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+  && pip install stacker stacker_blueprints runway PyYAML==3.13 --user \
+  && cd /tmp \
+  && wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+  && unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+  && mv terraform /usr/local/bin \
+  && rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 
 RUN rm -rf /root/.cache /root/.npm
 
@@ -20,7 +20,7 @@ RUN mkdir /src
 ENV PATH=/root/.local/bin/:$PATH
 
 RUN apk update \
- && apk add python3
+  && apk add python3
 
 
 WORKDIR /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,12 @@ MAINTAINER "Akito Nozaki <anozaki@onica.com>"
 
 ENV TERRAFORM_VERSION=0.11.10
 #ENV RUNWAY_VERSION=0.20.1
+ENV PYYAML_VERSION=3.13
 
 RUN apk add --no-cache nodejs nodejs-npm python python-dev py-pip build-base bash
 
 RUN npm i serverless -g \
- && pip install stacker stacker_blueprints runway PyYAML==3.13 --user \
+ && pip install stacker stacker_blueprints runway PyYAML==${PYYAML_VERSION} --user \
  && cd /tmp \
  && wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
  && unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,12 @@ ENV TERRAFORM_VERSION=0.11.10
 RUN apk add --no-cache nodejs nodejs-npm python python-dev py-pip build-base bash
 
 RUN npm i serverless -g \
-  && pip install stacker stacker_blueprints runway PyYAML==3.13 --user \
-  && cd /tmp \
-  && wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
-  && unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
-  && mv terraform /usr/local/bin \
-  && rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+ && pip install stacker stacker_blueprints runway PyYAML==3.13 --user \
+ && cd /tmp \
+ && wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+ && unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+ && mv terraform /usr/local/bin \
+ && rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 
 RUN rm -rf /root/.cache /root/.npm
 
@@ -20,7 +20,7 @@ RUN mkdir /src
 ENV PATH=/root/.local/bin/:$PATH
 
 RUN apk update \
-  && apk add python3
+ && apk add python3
 
 
 WORKDIR /src


### PR DESCRIPTION
I noticed that the `runway test` command was failing. I did a local build, and it turns out a pre-release version of PyYAML was being downloaded that is incompatible with the AWS CLI: 
`awscli 1.15.85 has requirement PyYAML<=3.13,>=3.10, but you'll have pyyaml 4.2b4 which is incompatible.`

This addresses that. I did a local test to confirm.